### PR TITLE
Update changelog files to be more modular

### DIFF
--- a/src/main/resources/db/changelog/changes/sharedlinks/db.changelog-sharedlinks-module-master.yaml
+++ b/src/main/resources/db/changelog/changes/sharedlinks/db.changelog-sharedlinks-module-master.yaml
@@ -1,4 +1,4 @@
 databaseChangeLog:
   - include:
-      file: ./v1.0-create-event-publication-table.sql
+      file: ./v1.0-sharedlinks-changelog.sql
       relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/changes/userauth/db.changelog-userauth-module-master.yaml
+++ b/src/main/resources/db/changelog/changes/userauth/db.changelog-userauth-module-master.yaml
@@ -1,4 +1,4 @@
 databaseChangeLog:
   - include:
-      file: ./v1.0-create-event-publication-table.sql
+      file: ./v1.0-userauth-changelog.sql
       relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/changes/userprofile/db.changelog-userprofile-module-master.yaml
+++ b/src/main/resources/db/changelog/changes/userprofile/db.changelog-userprofile-module-master.yaml
@@ -1,4 +1,4 @@
 databaseChangeLog:
   - include:
-      file: ./v1.0-create-event-publication-table.sql
+      file: ./v1.0-userprofile-changelog.sql
       relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/changes/workout_data/db.changelog-workout-module-master.yaml
+++ b/src/main/resources/db/changelog/changes/workout_data/db.changelog-workout-module-master.yaml
@@ -1,12 +1,12 @@
 databaseChangeLog:
   - include:
-      file: v1.0-workout-changelog.sql
+      file: ./v1.0-workout-changelog.sql
       relativeToChangelogFile: true
 
   - include:
-      file: v2.0-enable-uuid-generation-extension.sql
+      file: ./v2.0-enable-uuid-generation-extension.sql
       relativeToChangelogFile: true
 
   - include:
-      file: v3.0-import-exercise-data.sql
+      file: ./v3.0-import-exercise-data.sql
       relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -4,15 +4,15 @@ databaseChangeLog:
       relativeToChangelogFile: true
 
   - include:
-      file: changes/public/v1.0-create-event-publication-table.sql
+      file: changes/public/db.changelog-public-schema-master.yaml
       relativeToChangelogFile: true
 
   - include:
-      file: changes/userauth/v1.0-userauth-changelog.sql
+      file: changes/userauth/db.changelog-userauth-module-master.yaml
       relativeToChangelogFile: true
 
   - include:
-      file: changes/sharedlinks/v1.0-sharedlinks-changelog.sql
+      file: changes/sharedlinks/db.changelog-sharedlinks-module-master.yaml
       relativeToChangelogFile: true
 
   - include:
@@ -20,5 +20,5 @@ databaseChangeLog:
       relativeToChangelogFile: true
 
   - include:
-      file: changes/userprofile/v1.0-userprofile-changelog.sql
+      file: changes/userprofile/db.changelog-userprofile-module-master.yaml
       relativeToChangelogFile: true


### PR DESCRIPTION
I left only the **v1.0-schemas-changelog.sql** file to be imported by itself into **db.changelog-public-schema-master.yaml**.
Because I don't think we will need to import anymore files from that directory.